### PR TITLE
DIO 0 output on start button

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -56,6 +56,10 @@ void RobotContainer::ConfigureButtonBindings() {
             new frc2::RunCommand([this] {m_shooter.Stop();}, {&m_shooter})
     );
 
+    // Start button sets DIO 0 high when pressed, low when released
+    frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kStart)
+        .OnTrue(new frc2::InstantCommand([this] { m_dio0.Set(true); }))
+        .OnFalse(new frc2::InstantCommand([this] { m_dio0.Set(false); }));
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <frc/DigitalOutput.h>
 #include <frc/XboxController.h>
 #include <frc/controller/PIDController.h>
 #include <frc/controller/ProfiledPIDController.h>
@@ -38,6 +39,9 @@ class RobotContainer {
   frc::XboxController m_coDriverController{OIConstants::kCoDriverControllerPort};
 
   // The robot's subsystems and commands are defined here...
+
+  // Digital outputs
+  frc::DigitalOutput m_dio0{0};
 
   // The robot's subsystems
   DriveSubsystem m_drive;


### PR DESCRIPTION
## Summary
- Add DigitalOutput on DIO 0
- Set high when start button pressed, low when released

## Test plan
- [ ] Deploy and verify DIO 0 goes high when start is pressed
- [ ] Verify DIO 0 goes low when start is released